### PR TITLE
Add a configuration format section to the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,10 @@
     </a>
 </p>
 
+## TOML or YAML?
+
+[TOML configuration has been recently introduced to Alacritty](https://github.com/alacritty/alacritty/commit/bd4906722a1a026b01f06c94c33b13ff63a7e044) and it's not yet supported by any stable release of the software. If you need a YAML equivalent of the theme refer to [this link](https://github.com/rose-pine/alacritty/tree/7c3625f3d0f34359ba114e09b1ba3f3c1bed399a) (it will lead you to the latest version of this repository preceding the [TOML port](https://github.com/rose-pine/alacritty/commit/dfdb46476dc963d4e8784e4f32766ba603550bc6)).
+
 ## Usage
 
 1. Locate (or create) Alacritty's config file (refer to [the *Configuration* section of Alacritty's readme](https://github.com/alacritty/alacritty/tree/master#configuration))


### PR DESCRIPTION
As [evanpurkhiser](https://github.com/evanpurkhiser) pointed out in [this comment](https://github.com/rose-pine/alacritty/pull/5#issuecomment-1633316170), we should inform users of the absence of TOML configuration in Alacritty stable releases. 

This pull request adds a new section that contains the aforementioned information and a link to the latest version of the repository that precedes the TOML port.